### PR TITLE
Add a score property on base question

### DIFF
--- a/format/question/base/examples/invalid/no-score-type.json
+++ b/format/question/base/examples/invalid/no-score-type.json
@@ -1,0 +1,6 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {}
+}

--- a/format/question/base/examples/invalid/no-sum-score-failure.json
+++ b/format/question/base/examples/invalid/no-sum-score-failure.json
@@ -1,0 +1,9 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {
+    "type": "fixed",
+    "success": 5
+  }
+}

--- a/format/question/base/examples/invalid/no-sum-score-success.json
+++ b/format/question/base/examples/invalid/no-sum-score-success.json
@@ -1,0 +1,9 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {
+    "type": "fixed",
+    "failure": -1.5
+  }
+}

--- a/format/question/base/examples/invalid/score-failure-is-not-a-number.json
+++ b/format/question/base/examples/invalid/score-failure-is-not-a-number.json
@@ -1,0 +1,10 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {
+    "type": "fixed",
+    "success": 5,
+    "failure": "not-a-number"
+  }
+}

--- a/format/question/base/examples/invalid/score-is-not-an-object.json
+++ b/format/question/base/examples/invalid/score-is-not-an-object.json
@@ -1,0 +1,6 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": "not-an-object"
+}

--- a/format/question/base/examples/invalid/score-success-is-not-a-number.json
+++ b/format/question/base/examples/invalid/score-success-is-not-a-number.json
@@ -1,0 +1,10 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {
+    "type": "fixed",
+    "success": "not-a-number",
+    "failure": -1.5
+  }
+}

--- a/format/question/base/examples/invalid/unknown-score-type.json
+++ b/format/question/base/examples/invalid/unknown-score-type.json
@@ -1,0 +1,8 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {
+    "type": "foo-bar"
+  }
+}

--- a/format/question/base/examples/valid/with-fixed-score.json
+++ b/format/question/base/examples/valid/with-fixed-score.json
@@ -1,0 +1,10 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {
+    "type": "fixed",
+    "success": 5,
+    "failure": -1.5
+  }
+}

--- a/format/question/base/examples/valid/with-sum-score.json
+++ b/format/question/base/examples/valid/with-sum-score.json
@@ -1,0 +1,8 @@
+{
+  "id": "1",
+  "type": "application/x.type+json",
+  "title": "Question ?",
+  "score": {
+    "type": "sum"
+  }
+}

--- a/format/question/base/schema.json
+++ b/format/question/base/schema.json
@@ -56,6 +56,34 @@
     },
     "feedback": {
       "type": "string"
+    },
+    "score": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": ["sum"]
+            }
+          },
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": ["fixed"]
+            },
+            "success": {
+              "type": "number"
+            },
+            "failure": {
+              "type": "number"
+            }
+          },
+          "required": ["type", "success", "failure"]
+        }
+      ]
     }
   },
   "required": ["id", "type", "title"]

--- a/test/question/base-test.js
+++ b/test/question/base-test.js
@@ -42,6 +42,10 @@ describe('Base question', function () {
       it('may have a *feedback* property', function () {
         assert.isValid('global-feedback');
       });
+
+      it('may have a *score* property', function () {
+        assert.isValid('with-fixed-score');
+      });
     });
 
     describe('The *id* property', function () {
@@ -220,6 +224,58 @@ describe('Base question', function () {
         });
       });
     });
+
+    describe('The *score* property', function () {
+      it('must be an object', function () {
+        assert.hasError('score-is-not-an-object', {
+          '.score': 'should be object'
+        });
+      });
+
+      it('must have a *type* property', function () {
+        assert.hasError('no-score-type', {
+          '.score.type': 'property .type is required'
+        });
+      });
+
+      describe('The *type* property', function () {
+        it ('must be either "sum" or "fixed"', function () {
+          assert.hasError('unknown-score-type', {
+            '.score.type': 'should be equal to one of values'
+          });
+        });
+      });
+
+      describe('Scores of type "fixed"', function () {
+        it('must have a *success* property', function () {
+          assert.hasError('no-sum-score-success', {
+            '.score.success': 'property .success is required'
+          });
+        });
+
+        it('must have a *failure* property', function () {
+          assert.hasError('no-sum-score-failure', {
+            '.score.failure': 'property .failure is required'
+          });
+        });
+
+        describe('The *success* property', function () {
+          it('must be a number', function () {
+            assert.hasError('score-success-is-not-a-number', {
+              '.score.success': 'should be number'
+            });
+          });
+        })
+
+        describe('The *feedback* property', function () {
+          it('must be a string', function () {
+            assert.hasError('score-failure-is-not-a-number', {
+              '.score.failure': 'should be number'
+            });
+          });
+        })
+      })
+    });
   });
 
   describe('Examples', function () {
@@ -227,6 +283,8 @@ describe('Base question', function () {
       'with-metadata',
       'with-object',
       'with-resource',
+      'with-fixed-score',
+      'with-sum-score',
       'global-feedback',
       'hints-no-penalty',
       'hints-penalty'


### PR DESCRIPTION
cc @Elorfin, @david42, @charlotte42.

Score as the sum of each item:

```json
{
  "score": {
    "type": "sum"
  }
}
```

Fixed score attributed if all items are correct:

```json
{
  "score": {
    "type": "fixed",
    "success": 5,
    "failure": -1.5
  }
}
```