### PR TITLE
New content types

### DIFF
--- a/format/question/open/schema.json
+++ b/format/question/open/schema.json
@@ -11,7 +11,7 @@
           "enum": ["application/x.open+json"]
         },
         "contentType": {
-          "enum": ["text"],
+          "enum": ["text", "audio", "video"],
           "description": "The content type of the answer to submit to this question"
         },
         "maxLength": {


### PR DESCRIPTION
This adds the "audio" and "video" content types for open answers, which are necessary for oral production.